### PR TITLE
Fix deprecated writeTranslations() call with write() when available

### DIFF
--- a/src/FileStorage.php
+++ b/src/FileStorage.php
@@ -164,7 +164,7 @@ final class FileStorage implements Storage, TransferableStorage
             $path = (string) $resource;
             if (preg_match('|/'.$domain.'\.'.$locale.'\.([a-z]+)$|', $path, $matches)) {
                 $options['path'] = str_replace($matches[0], '', $path);
-                $this->writer->writeTranslations($catalogue, $matches[1], $options);
+                $this->writeTranslations($catalogue, $matches[1], $options);
                 $written = true;
             }
         }
@@ -176,7 +176,7 @@ final class FileStorage implements Storage, TransferableStorage
 
         $options['path'] = reset($this->dir);
         $format = isset($options['default_output_format']) ? $options['default_output_format'] : 'xlf';
-        $this->writer->writeTranslations($catalogue, $format, $options);
+        $this->writeTranslations($catalogue, $format, $options);
     }
 
     /**
@@ -209,5 +209,24 @@ final class FileStorage implements Storage, TransferableStorage
         }
 
         $this->catalogues[$locale] = $currentCatalogue;
+    }
+
+    /**
+     * This method calls the new TranslationWriter::write() if exist,
+     * otherwise fallback to TranslationWriter::writeTranslations() call
+     * to avoid BC breaks
+     *
+     * @param MessageCatalogue $catalogue
+     * @param $format
+     * @param array $options
+     */
+    private function writeTranslations(MessageCatalogue $catalogue, $format, $options = array())
+    {
+        if (method_exists($this->writer, 'write')) {
+            $this->writer->write($catalogue, $format, $options);
+        } else {
+            // This method is deprecated since 3.4, maintained to avoid BC breaks
+            $this->writer->writeTranslations($catalogue, $format, $options);
+        }
     }
 }

--- a/src/FileStorage.php
+++ b/src/FileStorage.php
@@ -214,7 +214,7 @@ final class FileStorage implements Storage, TransferableStorage
     /**
      * This method calls the new TranslationWriter::write() if exist,
      * otherwise fallback to TranslationWriter::writeTranslations() call
-     * to avoid BC breaks
+     * to avoid BC breaks.
      *
      * @param MessageCatalogue $catalogue
      * @param $format

--- a/src/FileStorage.php
+++ b/src/FileStorage.php
@@ -217,8 +217,8 @@ final class FileStorage implements Storage, TransferableStorage
      * to avoid BC breaks.
      *
      * @param MessageCatalogue $catalogue
-     * @param string $format
-     * @param array $options
+     * @param string           $format
+     * @param array            $options
      */
     private function writeTranslations(MessageCatalogue $catalogue, $format, array $options)
     {

--- a/src/FileStorage.php
+++ b/src/FileStorage.php
@@ -217,10 +217,10 @@ final class FileStorage implements Storage, TransferableStorage
      * to avoid BC breaks.
      *
      * @param MessageCatalogue $catalogue
-     * @param $format
+     * @param string $format
      * @param array $options
      */
-    private function writeTranslations(MessageCatalogue $catalogue, $format, $options = array())
+    private function writeTranslations(MessageCatalogue $catalogue, $format, array $options)
     {
         if (method_exists($this->writer, 'write')) {
             $this->writer->write($catalogue, $format, $options);

--- a/tests/Unit/FileStorageTest.php
+++ b/tests/Unit/FileStorageTest.php
@@ -51,11 +51,11 @@ class FileStorageTest extends TestCase
     public function testCreateNewCatalogue()
     {
         $writer = $this->getMockBuilder(TranslationWriter::class)
-            ->setMethods(['writeTranslations'])
+            ->setMethods([$this->getMethodNameToWriteTranslations()])
             ->disableOriginalConstructor()
             ->getMock();
         $writer->expects($this->once())
-            ->method('writeTranslations')
+            ->method($this->getMethodNameToWriteTranslations())
             ->with(
                 $this->isInstanceOf(MessageCatalogueInterface::class),
                 'xlf',
@@ -66,11 +66,11 @@ class FileStorageTest extends TestCase
         $storage->create(new Message('key', 'domain', 'en', 'Message'));
 
         $writer = $this->getMockBuilder(TranslationWriter::class)
-            ->setMethods(['writeTranslations'])
+            ->setMethods([$this->getMethodNameToWriteTranslations()])
             ->disableOriginalConstructor()
             ->getMock();
         $writer->expects($this->once())
-            ->method('writeTranslations')
+            ->method($this->getMethodNameToWriteTranslations())
             ->with(
                 $this->isInstanceOf(MessageCatalogueInterface::class),
                 'format',
@@ -84,11 +84,11 @@ class FileStorageTest extends TestCase
     public function testCreateExistingCatalogue()
     {
         $writer = $this->getMockBuilder(TranslationWriter::class)
-            ->setMethods(['writeTranslations'])
+            ->setMethods([$this->getMethodNameToWriteTranslations()])
             ->disableOriginalConstructor()
             ->getMock();
         $writer->expects($this->once())
-            ->method('writeTranslations')
+            ->method($this->getMethodNameToWriteTranslations())
             ->with(
                 $this->isInstanceOf(MessageCatalogueInterface::class),
                 'xlf',
@@ -127,11 +127,11 @@ class FileStorageTest extends TestCase
     public function testUpdate()
     {
         $writer = $this->getMockBuilder(TranslationWriter::class)
-            ->setMethods(['writeTranslations'])
+            ->setMethods([$this->getMethodNameToWriteTranslations()])
             ->disableOriginalConstructor()
             ->getMock();
         $writer->expects($this->exactly(2))
-            ->method('writeTranslations')
+            ->method($this->getMethodNameToWriteTranslations())
             ->with(
                 $this->isInstanceOf(MessageCatalogueInterface::class),
                 'xlf',
@@ -149,12 +149,12 @@ class FileStorageTest extends TestCase
     public function testDelete()
     {
         $writer = $this->getMockBuilder(TranslationWriter::class)
-            ->setMethods(['writeTranslations'])
+            ->setMethods([$this->getMethodNameToWriteTranslations()])
             ->disableOriginalConstructor()
             ->getMock();
 
         $writer->expects($this->once())
-            ->method('writeTranslations')
+            ->method($this->getMethodNameToWriteTranslations())
             ->with(
                 $this->callback(function (MessageCatalogueInterface $catalogue) {
                     return !$catalogue->defines('test_0', 'messages');
@@ -173,12 +173,12 @@ class FileStorageTest extends TestCase
     public function testImport()
     {
         $writer = $this->getMockBuilder(TranslationWriter::class)
-            ->setMethods(['writeTranslations'])
+            ->setMethods([$this->getMethodNameToWriteTranslations()])
             ->disableOriginalConstructor()
             ->getMock();
 
         $writer->expects($this->once())
-            ->method('writeTranslations')
+            ->method($this->getMethodNameToWriteTranslations())
             ->with(
                 $this->callback(function (MessageCatalogueInterface $catalogue) {
                     return $catalogue->defines('test_4711', 'messages');
@@ -234,5 +234,14 @@ class FileStorageTest extends TestCase
         }
 
         return new TranslationLoader();
+    }
+
+    private function getMethodNameToWriteTranslations()
+    {
+        if (method_exists(TranslationWriter::class, 'write')) {
+            return 'write';
+        }
+
+        return 'writeTranslations';
     }
 }


### PR DESCRIPTION
`TranslationWriter::writeTranslations()` is deprecated since 3.4, so we need a wrapper for it as well to avoid BC breaks