### PR TITLE
Adding attribute "name" on "unit" node for XLIFF 2.0

### DIFF
--- a/src/Dumper/Port/SymfonyPort.php
+++ b/src/Dumper/Port/SymfonyPort.php
@@ -38,6 +38,7 @@ class SymfonyPort
         foreach ($messages->all($domain) as $source => $target) {
             $translation = $dom->createElement('unit');
             $translation->setAttribute('id', strtr(substr(base64_encode(hash('sha256', $source, true)), 0, 7), '/+', '._'));
+            $translation->setAttribute('name', $source);
             $metadata = $messages->getMetadata($source, $domain);
 
             // Add notes section


### PR DESCRIPTION
This is valid according to the specification: http://docs.oasis-open.org/xliff/xliff-core/v2.0/os/xliff-core-v2.0-os.html#unit