### PR TITLE
Added deprecation notice on TranslationLoader interface and some comments

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,16 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release. 
 
+## 1.0.1
+
+### Fixed
+
+- The `LegacyTranslationReader` should also check for`Translation\SymfonyStorage\TranslationLoader`.
+
+### Changed
+
+- The `Translation\SymfonyStorage\TranslationLoader` was deprecated.
+
 ## 1.0.0
 
 ### Added

--- a/src/LegacyTranslationReader.php
+++ b/src/LegacyTranslationReader.php
@@ -12,7 +12,7 @@
 namespace Translation\SymfonyStorage;
 
 use Symfony\Component\Translation\MessageCatalogue;
-use Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader;
+use Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader as SymfonyTranslationLoader;
 
 /**
  * This loader is just a wrapper for Symfony TranslationLoader
@@ -29,7 +29,7 @@ final class LegacyTranslationReader // implements Symfony\Component\Translation\
 
     public function __construct($loader)
     {
-        if (!$loader instanceof TranslationLoader) {
+        if (!($loader instanceof TranslationLoader) && !($loader instanceof SymfonyTranslationLoader)) {
             throw new \LogicException(sprintf('PHP-Translation/SymfonyStorage does not support a TranslationReader of type "%s".', get_class($loader)));
         }
         $this->loader = $loader;

--- a/src/LegacyTranslationWriter.php
+++ b/src/LegacyTranslationWriter.php
@@ -22,6 +22,9 @@ use Symfony\Component\Translation\Writer\TranslationWriter;
  */
 final class LegacyTranslationWriter // implements Symfony\Component\Translation\Writer\TranslationWriterInterface
 {
+    /**
+     * @var TranslationWriter (This is a concrete class, the interface did not exist until sf 3.4)
+     */
     private $writer;
 
     public function __construct($writer)

--- a/src/TranslationLoader.php
+++ b/src/TranslationLoader.php
@@ -14,6 +14,8 @@ namespace Translation\SymfonyStorage;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**
+ * @deprecated Will be removed in 2.0. Please use Symfony\Component\Translation\Reader\TranslationReaderInterface.
+ *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
 interface TranslationLoader


### PR DESCRIPTION
The TranslationLoader interface is (almost) never used. It is currently only used in the converter package. 

I think this interface was added because we did not want a dependency on SymfonyFrameworkBundle. But since SF3.4 we got a new interface in the translation component. 

I think this interface should be removed. 