### PR TITLE
Prepare v2.0.0 release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## Unreleased
 
+## 2.0.0
+
+- Remove legacy layer used to support Symfony ^2.0
+- Add strict type hinting
+
 ## 1.1.0
 
 - Remove support of PHP < 7.2

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## 2.0.0
 
-- Remove legacy layer used to support Symfony ^2.0
+- Drop `symfony/translation` < 3.4 support by removing legacy layer
 - Add strict type hinting
 
 ## 1.1.0
@@ -112,5 +112,4 @@ to support legacy code.
 ## 0.1.0
 
 Init release
-
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2-dev"
+            "dev-master": "2.1-dev"
         }
     }
 }


### PR DESCRIPTION
Legacy layer have been removed, we now require `"php-translation/common": "^2.0"` & strict type hinting have been added.

Let's release a new major version. :)