### PR TITLE
look for translation files with intl domain suffix, too

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2,5 +2,5 @@ parameters:
 	ignoreErrors:
 		-
 			message: "#^Parameter \\#1 \\$catalogue of method Symfony\\\\Component\\\\Translation\\\\Writer\\\\TranslationWriterInterface\\:\\:write\\(\\) expects Symfony\\\\Component\\\\Translation\\\\MessageCatalogue, Symfony\\\\Component\\\\Translation\\\\MessageCatalogueInterface given\\.$#"
-			count: 2
+			count: 3
 			path: src/FileStorage.php

--- a/src/FileStorage.php
+++ b/src/FileStorage.php
@@ -140,9 +140,16 @@ final class FileStorage implements Storage, TransferableStorage
         $resources = $catalogue->getResources();
         $options = $this->options;
         $written = false;
+        $intlDomainSuffix = '(\\' . MessageCatalogueInterface::INTL_DOMAIN_SUFFIX . ')';
+        $searchPatternWithIntl = '|/'.$domain . $intlDomainSuffix . '\.'.$locale.'\.([a-z]+)$|';
+        $searchPatternWithoutIntl = str_replace($intlDomainSuffix, '', $searchPatternWithIntl);
         foreach ($resources as $resource) {
             $path = (string) $resource;
-            if (preg_match('|/'.$domain.'\.'.$locale.'\.([a-z]+)$|', $path, $matches)) {
+            if (preg_match($searchPatternWithIntl, $path, $matches)) {
+                $options['path'] = str_replace($matches[0], '', $path);
+                $this->writer->write($catalogue, $matches[2], $options);
+                $written = true;
+            } elseif (preg_match($searchPatternWithoutIntl, $path, $matches)) {
                 $options['path'] = str_replace($matches[0], '', $path);
                 $this->writer->write($catalogue, $matches[1], $options);
                 $written = true;

--- a/src/FileStorage.php
+++ b/src/FileStorage.php
@@ -140,7 +140,8 @@ final class FileStorage implements Storage, TransferableStorage
         $resources = $catalogue->getResources();
         $options = $this->options;
         $written = false;
-        $intlDomainSuffix = '(\\' . MessageCatalogueInterface::INTL_DOMAIN_SUFFIX . ')';
+        // $intlDomainSuffix = '(\\' . MessageCatalogueInterface::INTL_DOMAIN_SUFFIX . ')'; # not available in older Symfony versions
+        $intlDomainSuffix = '(\\' . '+intl-icu' . ')';
         $searchPatternWithIntl = '|/'.$domain . $intlDomainSuffix . '\.'.$locale.'\.([a-z]+)$|';
         $searchPatternWithoutIntl = str_replace($intlDomainSuffix, '', $searchPatternWithIntl);
         foreach ($resources as $resource) {

--- a/src/FileStorage.php
+++ b/src/FileStorage.php
@@ -141,8 +141,8 @@ final class FileStorage implements Storage, TransferableStorage
         $options = $this->options;
         $written = false;
         // $intlDomainSuffix = '(\\' . MessageCatalogueInterface::INTL_DOMAIN_SUFFIX . ')'; # not available in older Symfony versions
-        $intlDomainSuffix = '(\\' . '+intl-icu' . ')';
-        $searchPatternWithIntl = '|/'.$domain . $intlDomainSuffix . '\.'.$locale.'\.([a-z]+)$|';
+        $intlDomainSuffix = '(\\'.'+intl-icu'.')';
+        $searchPatternWithIntl = '|/'.$domain.$intlDomainSuffix.'\.'.$locale.'\.([a-z]+)$|';
         $searchPatternWithoutIntl = str_replace($intlDomainSuffix, '', $searchPatternWithIntl);
         foreach ($resources as $resource) {
             $path = (string) $resource;


### PR DESCRIPTION
This PR changes the translation update logic for picking the file to write into. The new version looks for Intl ICU files first. For example it detects `messages+intl-icu.de.yaml` and prefers this against `messages.de.yaml`.