### PR TITLE
Simplify badge list and other minor README tweaks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,12 +1,9 @@
 # Symfony Storage
 
 [![Latest Version](https://img.shields.io/github/release/php-translation/symfony-storage.svg?style=flat-square)](https://github.com/php-translation/symfony-storage/releases)
-[![Build Status](https://img.shields.io/travis/php-translation/symfony-storage.svg?style=flat-square)](https://travis-ci.org/php-translation/symfony-storage)
-[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/php-translation/symfony-storage.svg?style=flat-square)](https://scrutinizer-ci.com/g/php-translation/symfony-storage)
-[![Quality Score](https://img.shields.io/scrutinizer/g/php-translation/symfony-storage.svg?style=flat-square)](https://scrutinizer-ci.com/g/php-translation/symfony-storage)
 [![Total Downloads](https://img.shields.io/packagist/dt/php-translation/symfony-storage.svg?style=flat-square)](https://packagist.org/packages/php-translation/symfony-storage)
 
-This is an PHP-translation storage adapter that uses Symfony's translation writer
+This is a PHP Translation storage adapter that uses Symfony's translation writer
 and loader.
 
 ### Install
@@ -25,4 +22,4 @@ make static
 
 ### Documentation
 
-Read our documentation at [http://php-translation.readthedocs.io](http://php-translation.readthedocs.io/en/latest/).
+Read the full documentation at [https://php-translation.readthedocs.io](https://php-translation.readthedocs.io/en/latest/).


### PR DESCRIPTION
- Travis CI was dropped in favor of GitHub Actions and does not work anymore
- Scrutinizer does not work anymore, the last build was 2 years ago
- SensioLabsInsight was migrated to SymfonyInsight, but there's no this project, it returns 404